### PR TITLE
Windows namespace issue.

### DIFF
--- a/src/namespace.ts
+++ b/src/namespace.ts
@@ -11,6 +11,8 @@ export class Namespace
 
     public async getNamespace(filePath: string, type: string)
     {
+        filePath = filePath.replace(/\\/g, '/');
+
         let composerFile = this.resolveComposerFileForPath(filePath);
 
         if (!composerFile) {


### PR DESCRIPTION
As of now, in Windows, the user file name input prompt populates the path with backward slashes. Because of that, the plugin is unable to detect the composer file by using the `findClosestComposerFile` method. This method uses forward slash for checks.

This windows OS related bug can be resolved by replacing `\` in the argument `filePath` with `/`.

With the existing bug, the plugin is only half useful. It is quite annoying to type in the namespace every time. Please check, merge and update on visual studio store.

Thank you.
